### PR TITLE
support coupang.com #4

### DIFF
--- a/coupang.com.js
+++ b/coupang.com.js
@@ -1,0 +1,28 @@
+var css = `
+  .--oxy-blocker {
+    {{css:item}}
+  }
+
+  .--oxy-blocker::after {
+    {{css:image}}
+  }
+
+  .--oxy-blocker > .detail-link > img,
+  .--oxy-blocker > .detail-link > .thumbnail {
+    {{css:cover}}
+  }
+
+  #productList > li > * {
+    {{css:transition}}
+  }
+
+  .--oxy-blocker > * {
+    {{css:hide}}
+  }
+`;
+
+OxyBlocker.initialize(css, {
+  wrap: '.search-content',
+  list: '#productList > li:not(.--oxy-blocker-processed)',
+  title: '.title'
+}, true);

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,7 @@
       "js": ["common.js", "search.11st.co.kr.js"], "run_at": "document_end"
     },
     {
-      "matches": [ "https://www.coupang.com/np/*" ],
+      "matches": [ "https://www.coupang.com/*" ],
       "js": ["common.js", "coupang.com.js"], "run_at": "document_end"
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
     "http://shopping.naver.com/*",
     "http://search.daum.net/*",
     "http://shopping.daum.net/*",
-    "http://search.11st.co.kr/*"
+    "http://search.11st.co.kr/*",
+    "https://www.coupang.com/*"
   ],
 
   "web_accessible_resources" : [
@@ -47,6 +48,10 @@
     {
       "matches": [ "http://search.11st.co.kr/SearchPrdAction.tmall*" ],
       "js": ["common.js", "search.11st.co.kr.js"], "run_at": "document_end"
+    },
+    {
+      "matches": [ "https://www.coupang.com/np/*" ],
+      "js": ["common.js", "coupang.com.js"], "run_at": "document_end"
     }
   ]
 }


### PR DESCRIPTION
쿠팡지원을 추가하였습니다. 
PC용 페이지에서 공통으로 사용하는 아이템 마크업을 찾아 적용했기 때문에, 
단순 카달로그 페이지와 검색결과 페이지 모두에서 동작합니다.
